### PR TITLE
Expose the Phaser UI namespace.

### DIFF
--- a/test/gulpfile.js/config.js
+++ b/test/gulpfile.js/config.js
@@ -30,7 +30,7 @@ const PHASER_BUILDS = 'node_modules/phaser-ce/build';
 // Note: Other features are missing in the 'no physics' build, like Tilemaps.
 //    If you're getting exceptions when trying to create these game objects,
 //    change to another build option listed above.
-const PHASER = `${PHASER_BUILDS}/custom/phaser-no-physics.js`;
+const PHASER = `${PHASER_BUILDS}/custom/phaser-arcade-physics.js`;
 
 // Build output directories.
 exports.dirs = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,9 @@ module.exports = {
     entry: "./src/index.js",
     output: {
         path: 'build/',
-        filename: "phaser-ui.js"
+        filename: "phaser-ui.js",
+        library: 'phaserUi',
+        libraryTarget: 'umd'
     }
     /*,
     module: {


### PR DESCRIPTION
Saw your [post](http://www.html5gamedevs.com/topic/28476-issues-when-creating-a-small-foss-phaserio-ui-library/) at HTML5 Gamedev Forums.

Tried running the sample project, but got the "class extending undefined" exception thing. This is because only builds including Arcade Physics have the Particles system included. So, you must use to the AP enabled builds for testing those.

As for the Webpack you need to expose the namespace of your library to use it, so at least the `output.library` option must be present (more info [here](https://webpack.js.org/guides/author-libraries/)).

Good luck with your project.